### PR TITLE
Update crate to be compatible with nix 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/Mobivity/nix-ptsname_r-shim"
 repository = "https://github.com/Mobivity/nix-ptsname_r-shim"
 
 [dependencies]
-nix = "0.9.0"
+nix = "^0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,7 @@ pub fn ptsname_r(fd: &PtyMaster) -> Result<String> {
     unsafe {
         match ioctl(fd.as_raw_fd(), TIOCPTYGNAME as c_ulong, &buf) {
             0 => {
-                let res = CStr::from_ptr(buf.as_ptr())
-                    .to_string_lossy()
-                    .into_owned();
+                let res = CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned();
                 Ok(res)
             }
             _ => Err(Error::last()),
@@ -58,18 +56,17 @@ pub fn ptsname_r(fd: &PtyMaster) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use nix::fcntl::O_RDWR;
+    use nix::fcntl::OFlag;
     use nix::pty::posix_openpt;
     use std::os::unix::prelude::*;
     use super::ptsname_r;
 
     /// Test data copying of `ptsname_r`
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos",
-                target_os = "ios"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "ios"))]
     fn test_ptsname_r_copy() {
         // Open a new PTTY master
-        let master_fd = posix_openpt(O_RDWR).unwrap();
+        let master_fd = posix_openpt(OFlag::O_RDWR).unwrap();
         assert!(master_fd.as_raw_fd() > 0);
 
         // Get the name of the slave


### PR DESCRIPTION
This PR bumps the version number for nix to `^0.10.0` since it's been out for a few months now, and adjusts a test to import an O_ flag that changed in nix 0.10.